### PR TITLE
Return most recent license

### DIFF
--- a/packages/uls/src/hamkit/uls/_uls.py
+++ b/packages/uls/src/hamkit/uls/_uls.py
@@ -82,7 +82,8 @@ class ULS(object):
             Operator_Class,
             Group_Code,
             Region_Code
-            FROM LicenseView WHERE Call_Sign = ?;""",
+            FROM LicenseView WHERE Call_Sign = ?
+            ORDER BY Unique_System_Identifier DESC;""",
             (call_sign.upper().strip(),),
         )
         row = cursor.fetchone()


### PR DESCRIPTION
Modifies the call sign search's query to use the unique identifier to get the most recent call sign issued.
Fixes #1. 